### PR TITLE
script: QueryDSL 및 MinIO 버전 업그레이드 및 보안 취약점 대응

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,9 +44,10 @@ dependencies {
 	//Thymeleaf
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
-	//Query DSL
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	//OpenFeign Query DSL
+	annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0"
+	implementation "io.github.openfeign.querydsl:querydsl-jpa:7.0"
+	implementation "io.github.openfeign.querydsl:querydsl-jpa-spring:7.0"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
@@ -57,7 +58,10 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
 
 	//Minio
-	implementation 'io.minio:minio:8.5.7'
+	implementation 'io.minio:minio:8.5.17'
+	implementation "org.bouncycastle:bcprov-jdk18on:1.81"
+	implementation "org.apache.commons:commons-lang3:3.18.0"
+	implementation "org.apache.commons:commons-compress:1.28.0"
 
 	//엘라스틱 서치
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'


### PR DESCRIPTION
- QueryDSL을 `com.querydsl` → `io.github.openfeign.querydsl`(v7.0)로 교체
- MinIO Java SDK를 8.5.17로 업그레이드 → 전이 의존성(Bouncy Castle) 보안 취약점 해결
  - 취약 전이 의존성 버전 오버라이드:
    - org.bouncycastle:bcprov-jdk18on → 1.81
    - org.apache.commons:commons-compress → 1.28.0
    - org.apache.commons:commons-lang3 → 3.18.0